### PR TITLE
Update naskit-client.gemspec

### DIFF
--- a/naskit-client.gemspec
+++ b/naskit-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock", "~> 1.11.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Fixes:

Details
CVE-2020-36327
high severity
Vulnerable versions: >= 1.16.0, < 2.2.10
Patched version: 2.2.10
Bundler 1.16.0 through 2.2.9 and 2.2.11 through 2.2.17 sometimes chooses a dependency source based on the highest gem version number, which means that a rogue gem found at a public source may be chosen, even if the intended choice was a private gem that is a dependency of another private gem that is explicitly depended on by the application.

CVE-2019-3881
high severity
Vulnerable versions: >= 1.14.0, < 2.1.0
Patched version: 2.1.0
Bundler prior to 2.1.0 uses a predictable path in /tmp/, created with insecure permissions as a storage location for gems, if locations under the user's home directory are not available. If Bundler is used in a scenario where the user does not have a writable home directory, an attacker could place malicious code in this directory that would be later loaded and executed.

